### PR TITLE
Couple of fixes for microblogs and mentions.

### DIFF
--- a/lib/src/api/posts.dart
+++ b/lib/src/api/posts.dart
@@ -23,7 +23,7 @@ class APIPosts {
 
   Future<PostListModel> list(
     FeedSource source, {
-    int? page,
+    String? page,
     FeedSort? sort,
     List<String>? langs,
     bool? usePreferredLangs,
@@ -34,7 +34,7 @@ class APIPosts {
 
     final path = source.getPostsPath()!;
     final query = queryParams({
-      'p': page?.toString(),
+      'p': page,
       'sort': sort?.name,
       'lang': langs?.join(','),
       'usePreferredLangs': (usePreferredLangs ?? false).toString(),

--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -300,7 +300,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody> {
             ),
         PostType.microblog => context.read<SettingsController>().api.posts.list(
               widget.source,
-              page: int.parse(pageKey),
+              page: pageKey.isEmpty ? null : pageKey,
               sort: widget.sort,
               usePreferredLangs: whenLoggedIn(context,
                   context.read<SettingsController>().useAccountLangFilter),

--- a/lib/src/widgets/markdown_mention.dart
+++ b/lib/src/widgets/markdown_mention.dart
@@ -150,10 +150,10 @@ class MentionWidgetState extends State<MentionWidget> {
     final modifier = widget.name[0];
     final split = widget.name.substring(1).split('@');
     final name = split[0];
-    final host = (split.length > 1 && split[1] != widget.originInstance)
+    final host = (split.length > 1)
         ? split[1]
-        : null;
-    final cacheKey = host != null ? '$name@$host' : name;
+        : widget.originInstance;
+    final cacheKey = '$name@$host';
 
     setState(() {
       _displayName = modifier + name;
@@ -164,7 +164,7 @@ class MentionWidgetState extends State<MentionWidget> {
         if (!userMentionCache.containsKey(cacheKey)) {
           userMentionCache[cacheKey] =
               await context.read<SettingsController>().api.users.getByName(
-                    host != null ? '@$name@$host' : name,
+                    '@$name@$host',
                   );
         }
         final user = userMentionCache[cacheKey]!;
@@ -183,7 +183,7 @@ class MentionWidgetState extends State<MentionWidget> {
         if (!magazineMentionCache.containsKey(cacheKey)) {
           magazineMentionCache[cacheKey] =
               await context.read<SettingsController>().api.magazines.getByName(
-                    host != null ? '$name@$host' : name,
+                    '$name@$host',
                   );
         }
         final magazine = magazineMentionCache[cacheKey]!;


### PR DESCRIPTION
Updated microblog pagekey to match entries for feed screen.
For the mention cache, the comparison to the originInstance broke mentions for users which weren't from the logged in server since the search by username requires @user@instance if it is a federated user and the comparison resulted in host being null.