### PR TITLE
Decode lemmy thread and comment responses as utf8.

### DIFF
--- a/lib/src/api/comments.dart
+++ b/lib/src/api/comments.dart
@@ -109,7 +109,7 @@ class APIComments {
         httpErrorHandler(response, message: 'Failed to load comments');
 
         return CommentListModel.fromLemmy(
-            jsonDecode(response.body) as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, Object?>);
     }
   }
 
@@ -150,7 +150,7 @@ class APIComments {
 
         httpErrorHandler(response, message: 'Failed to load user');
 
-        final json = jsonDecode(response.body) as Map<String, Object?>;
+        final json = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, Object?>;
 
         json['next_page'] =
             lemmyCalcNextIntPage(json['comments'] as List<dynamic>, page);
@@ -185,7 +185,7 @@ class APIComments {
           (jsonDecode(response.body)['comments'] as List<dynamic>)
               .firstWhere((item) => item['comment']['id'] == commentId),
           possibleChildren:
-              jsonDecode(response.body)['comments'] as List<dynamic>,
+              jsonDecode(utf8.decode(response.bodyBytes))['comments'] as List<dynamic>,
         );
     }
   }
@@ -224,7 +224,7 @@ class APIComments {
         httpErrorHandler(response, message: 'Failed to send vote');
 
         return CommentModel.fromLemmy(
-            jsonDecode(response.body)['comment_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['comment_view'] as Map<String, Object?>);
     }
   }
 
@@ -282,7 +282,7 @@ class APIComments {
         httpErrorHandler(response, message: 'Failed to create comment');
 
         return CommentModel.fromLemmy(
-            jsonDecode(response.body)['comment_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['comment_view'] as Map<String, Object?>);
     }
   }
 
@@ -322,7 +322,7 @@ class APIComments {
         httpErrorHandler(response, message: 'Failed to edit comment');
 
         return CommentModel.fromLemmy(
-            jsonDecode(response.body)['comment_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['comment_view'] as Map<String, Object?>);
     }
   }
 

--- a/lib/src/api/threads.dart
+++ b/lib/src/api/threads.dart
@@ -119,7 +119,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to load posts');
 
         return PostListModel.fromLemmy(
-            jsonDecode(response.body) as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, Object?>);
     }
   }
 
@@ -146,7 +146,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to load post');
 
         return PostModel.fromLemmy(
-            jsonDecode(response.body)['post_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['post_view'] as Map<String, Object?>);
     }
   }
 
@@ -246,7 +246,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to edit entry');
 
         return PostModel.fromLemmy(
-            jsonDecode(response.body)['post_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['post_view'] as Map<String, Object?>);
     }
   }
 
@@ -317,7 +317,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to create entry');
 
         return PostModel.fromLemmy(
-            jsonDecode(response.body)['post_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['post_view'] as Map<String, Object?>);
     }
   }
 
@@ -370,7 +370,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to create entry');
 
         return PostModel.fromLemmy(
-            jsonDecode(response.body)['post_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['post_view'] as Map<String, Object?>);
     }
   }
 
@@ -452,7 +452,7 @@ class APIThreads {
         httpErrorHandler(response, message: 'Failed to create entry');
 
         return PostModel.fromLemmy(
-            jsonDecode(response.body)['post_view'] as Map<String, Object?>);
+            jsonDecode(utf8.decode(response.bodyBytes))['post_view'] as Map<String, Object?>);
     }
   }
 


### PR DESCRIPTION
Decodes lemmy thread and comments as utf8 to fix incorrect characters. Couldn't find a similar issue with mbin's encoding so haven't made any changes to mbin's response handling.
Should fix issue #49.