### PR TITLE
Fix bug when navigating to magazine feed when type action is set to t…

### DIFF
--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -355,14 +355,16 @@ class _FeedScreenState extends State<FeedScreen> {
                   String name when name == feedActionSetType(context).name => [
                       FeedScreenBody(
                         key: _getFeedKey(0),
-                        source: _filter,
+                        source: widget.source ?? _filter,
+                        sourceId: widget.sourceId,
                         sort: _sort ?? _defaultSortFromMode(PostType.thread),
                         mode: PostType.thread,
                         details: widget.details,
                       ),
                       FeedScreenBody(
                         key: _getFeedKey(1),
-                        source: _filter,
+                        source: widget.source ?? _filter,
+                        sourceId: widget.sourceId,
                         sort: _sort ?? _defaultSortFromMode(PostType.microblog),
                         mode: PostType.microblog,
                         details: widget.details,


### PR DESCRIPTION
Found bug that when navigating to a magazine screen when the type action is set to tabs, that the magazine screen would display the main feed instead of the magazine feed.