### PR TITLE
Update navigation handling so pages keep state when switching between them.

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -27,7 +27,9 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   int _navIndex = 0;
   final PageController _pageController = PageController();
-  Key _refreshKey = UniqueKey();
+  Key _feedKey = UniqueKey();
+  Key _exploreKey = UniqueKey();
+  Key _accountKey = UniqueKey();
 
   void _changeNav(int newIndex) {
     setState(() {
@@ -41,7 +43,9 @@ class _AppState extends State<App> {
     final appController = context.watch<AppController>();
     appController.refreshState = () {
       setState(() {
-        _refreshKey = UniqueKey();
+        _feedKey = UniqueKey();
+        _exploreKey = UniqueKey();
+        _accountKey = UniqueKey();
       });
     };
 
@@ -198,23 +202,15 @@ class _AppState extends State<App> {
                       ),
                     Expanded(
                       child: PageView(
-                        key: _refreshKey,
                         controller: _pageController,
                         children: [
-                          FeedScreen(),
-                          ExploreScreen(),
-                          AccountScreen(),
+                          FeedScreen(key: _feedKey),
+                          ExploreScreen(key: _exploreKey),
+                          AccountScreen(key: _accountKey),
                           SettingsScreen(),
                         ],
                       )
                     ),
-                    // Expanded(
-                    //     child: const [
-                    //   FeedScreen(),
-                    //   ExploreScreen(),
-                    //   AccountScreen(),
-                    //   SettingsScreen(),
-                    // ][_navIndex]),
                   ]),
                 );
               },

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -26,16 +26,24 @@ class App extends StatefulWidget {
 
 class _AppState extends State<App> {
   int _navIndex = 0;
+  final PageController _pageController = PageController();
+  Key _refreshKey = UniqueKey();
 
   void _changeNav(int newIndex) {
     setState(() {
       _navIndex = newIndex;
     });
+    _pageController.jumpToPage(_navIndex);
   }
 
   @override
   Widget build(BuildContext context) {
     final appController = context.watch<AppController>();
+    appController.refreshState = () {
+      setState(() {
+        _refreshKey = UniqueKey();
+      });
+    };
 
     final intlLocale =
         intl_locale.Locale.tryParse(appController.profile.appLanguage);
@@ -189,12 +197,24 @@ class _AppState extends State<App> {
                         width: 1,
                       ),
                     Expanded(
-                        child: const [
-                      FeedScreen(),
-                      ExploreScreen(),
-                      AccountScreen(),
-                      SettingsScreen(),
-                    ][_navIndex]),
+                      child: PageView(
+                        key: _refreshKey,
+                        controller: _pageController,
+                        children: [
+                          FeedScreen(),
+                          ExploreScreen(),
+                          AccountScreen(),
+                          SettingsScreen(),
+                        ],
+                      )
+                    ),
+                    // Expanded(
+                    //     child: const [
+                    //   FeedScreen(),
+                    //   ExploreScreen(),
+                    //   AccountScreen(),
+                    //   SettingsScreen(),
+                    // ][_navIndex]),
                   ]),
                 );
               },

--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -75,6 +75,7 @@ class AppController with ChangeNotifier {
   late Function refreshState;
 
   Future<void> init() async {
+    refreshState = (){};
     final mainProfileTemp = await _mainProfileRecord.get(db) as String?;
     if (mainProfileTemp != null) {
       _mainProfile = mainProfileTemp;
@@ -136,6 +137,7 @@ class AppController with ChangeNotifier {
     _builtProfile = ProfileRequired.fromOptional(
       (await getProfile(_mainProfile)).merge(_selectedProfileValue),
     );
+    refreshState();
   }
 
   Future<void> updateProfile(ProfileOptional value) async {

--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -72,6 +72,8 @@ class AppController with ChangeNotifier {
   late Map<String, FilterList> _filterLists;
   Map<String, FilterList> get filterLists => _filterLists;
 
+  late Function refreshState;
+
   Future<void> init() async {
     final mainProfileTemp = await _mainProfileRecord.get(db) as String?;
     if (mainProfileTemp != null) {
@@ -346,6 +348,7 @@ class AppController with ChangeNotifier {
     magazineMentionCache.clear();
 
     notifyListeners();
+    refreshState();
 
     await _selectedAccountRecord.put(db, _selectedAccount);
   }

--- a/lib/src/screens/account/account_screen.dart
+++ b/lib/src/screens/account/account_screen.dart
@@ -17,9 +17,14 @@ class AccountScreen extends StatefulWidget {
   State<AccountScreen> createState() => _AccountScreenState();
 }
 
-class _AccountScreenState extends State<AccountScreen> {
+class _AccountScreenState extends State<AccountScreen> with AutomaticKeepAliveClientMixin<AccountScreen> {
+
+  @override
+  bool get wantKeepAlive => true;
+
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return whenLoggedIn(
           context,
           context.read<AppController>().serverSoftware == ServerSoftware.lemmy

--- a/lib/src/screens/account/messages/messages_screen.dart
+++ b/lib/src/screens/account/messages/messages_screen.dart
@@ -16,9 +16,12 @@ class MessagesScreen extends StatefulWidget {
   State<MessagesScreen> createState() => _MessagesScreenState();
 }
 
-class _MessagesScreenState extends State<MessagesScreen> {
+class _MessagesScreenState extends State<MessagesScreen> with AutomaticKeepAliveClientMixin<MessagesScreen> {
   final PagingController<String, MessageThreadModel> _pagingController =
       PagingController(firstPageKey: '');
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -51,6 +54,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return RefreshIndicator(
       onRefresh: () => Future.sync(
         () => _pagingController.refresh(),

--- a/lib/src/screens/account/notification/notification_screen.dart
+++ b/lib/src/screens/account/notification/notification_screen.dart
@@ -20,11 +20,14 @@ class NotificationsScreen extends StatefulWidget {
   State<NotificationsScreen> createState() => _NotificationsScreenState();
 }
 
-class _NotificationsScreenState extends State<NotificationsScreen> {
+class _NotificationsScreenState extends State<NotificationsScreen> with AutomaticKeepAliveClientMixin<NotificationsScreen> {
   NotificationsFilter filter = NotificationsFilter.all;
 
   final PagingController<String, NotificationModel> _pagingController =
       PagingController(firstPageKey: '');
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -62,6 +65,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final currentNotificationFilter =
         notificationFilterSelect(context).getOption(filter);
 

--- a/lib/src/screens/account/self_feed.dart
+++ b/lib/src/screens/account/self_feed.dart
@@ -12,8 +12,11 @@ class SelfFeed extends StatefulWidget {
   State<SelfFeed> createState() => _SelfFeedState();
 }
 
-class _SelfFeedState extends State<SelfFeed> {
+class _SelfFeedState extends State<SelfFeed> with AutomaticKeepAliveClientMixin<SelfFeed> {
   UserModel? _meUser;
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -33,6 +36,7 @@ class _SelfFeedState extends State<SelfFeed> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     if (_meUser == null) {
       return const LoadingTemplate();
     }

--- a/lib/src/screens/explore/explore_screen.dart
+++ b/lib/src/screens/explore/explore_screen.dart
@@ -20,7 +20,7 @@ class ExploreScreen extends StatefulWidget {
   State<ExploreScreen> createState() => _ExploreScreenState();
 }
 
-class _ExploreScreenState extends State<ExploreScreen> {
+class _ExploreScreenState extends State<ExploreScreen> with AutomaticKeepAliveClientMixin<ExploreScreen> {
   String search = '';
   final searchDebounce = Debouncer(duration: const Duration(milliseconds: 500));
 
@@ -31,6 +31,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
 
   final PagingController<String, dynamic> _pagingController =
       PagingController(firstPageKey: '');
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -132,6 +135,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     const chipPadding = EdgeInsets.symmetric(vertical: 6, horizontal: 4);
 
     final currentExploreSort = exploreSortSelection(context).getOption(sort);

--- a/lib/src/screens/explore/user_screen.dart
+++ b/lib/src/screens/explore/user_screen.dart
@@ -466,9 +466,12 @@ class UserScreenBody extends StatefulWidget {
   State<UserScreenBody> createState() => _UserScreenBodyState();
 }
 
-class _UserScreenBodyState extends State<UserScreenBody> {
+class _UserScreenBodyState extends State<UserScreenBody> with AutomaticKeepAliveClientMixin<UserScreenBody> {
   final PagingController<String, dynamic> _pagingController =
       PagingController(firstPageKey: '');
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void didUpdateWidget(covariant oldWidget) {
@@ -577,6 +580,7 @@ class _UserScreenBodyState extends State<UserScreenBody> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return RefreshIndicator(
       onRefresh: () => Future.sync(() => _pagingController.refresh()),
       child: CustomScrollView(

--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -39,12 +39,15 @@ class FeedScreen extends StatefulWidget {
   State<FeedScreen> createState() => _FeedScreenState();
 }
 
-class _FeedScreenState extends State<FeedScreen> {
+class _FeedScreenState extends State<FeedScreen> with AutomaticKeepAliveClientMixin<FeedScreen> {
   final _fabKey = GlobalKey<FloatingMenuState>();
   final List<GlobalKey<_FeedScreenBodyState>> _feedKeyList = [];
   late FeedSource _filter;
   late PostType _mode;
   FeedSort? _sort;
+
+  @override
+  bool get wantKeepAlive => true;
 
   _getFeedKey(int index) {
     while (index >= _feedKeyList.length) {
@@ -73,6 +76,7 @@ class _FeedScreenState extends State<FeedScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final sort = _sort ?? _defaultSortFromMode(_mode);
 
     final currentFeedModeOption = feedTypeSelect(context).getOption(_mode);
@@ -574,7 +578,7 @@ class FeedScreenBody extends StatefulWidget {
   State<FeedScreenBody> createState() => _FeedScreenBodyState();
 }
 
-class _FeedScreenBodyState extends State<FeedScreenBody> {
+class _FeedScreenBodyState extends State<FeedScreenBody>  with AutomaticKeepAliveClientMixin<FeedScreenBody> {
   final _pagingController =
       PagingController<String, PostModel>(firstPageKey: '');
   final _scrollController = ScrollController();
@@ -589,6 +593,9 @@ class _FeedScreenBodyState extends State<FeedScreenBody> {
 
     _pagingController.addPageRequestListener(_fetchPage);
   }
+
+  @override
+  bool get wantKeepAlive => true;
 
   Future<void> _fetchPage(String pageKey) async {
     if (pageKey.isEmpty) _filterListWarnings.clear();
@@ -700,6 +707,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return RefreshIndicator(
       onRefresh: () => Future.sync(
         () => _pagingController.refresh(),

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -197,13 +197,14 @@ class DefaultTabControllerListener extends StatefulWidget {
 
 class _DefaultTabControllerListenerState
     extends State<DefaultTabControllerListener> {
-  late final void Function()? _listener;
+  void Function()? _listener;
   TabController? _tabController;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       final tabController = DefaultTabController.of(context);
       _listener = () {
         if (tabController.indexIsChanging) {
@@ -228,7 +229,7 @@ class _DefaultTabControllerListenerState
   @override
   void dispose() {
     if (_listener != null && _tabController != null) {
-      _tabController!.removeListener(_listener);
+      _tabController!.removeListener(_listener!);
     }
     super.dispose();
   }


### PR DESCRIPTION
Should keep state when switching between pages on the navigation bar as well as between feed tabs.
Adds a callback to refresh widgets state when switching between accounts.