### PR TITLE
Piefed - enable handling user about for piefed

### DIFF
--- a/lib/src/api/users.dart
+++ b/lib/src/api/users.dart
@@ -222,7 +222,14 @@ class APIUsers {
         return null;
 
       case ServerSoftware.piefed:
-        throw UnimplementedError();
+        const path = '/user/save_user_settings';
+
+        final response = await client.put(
+          path,
+          body: {'bio': about},
+        );
+
+        return null;
     }
   }
 


### PR DESCRIPTION
This adjusts the `api.users.updateProfile()` for Piefed. It matches the below PR on the Piefed project that adds the `api/alpha/user/save_user_settings` route.

Piefed side PR: https://codeberg.org/rimu/pyfedi/pulls/545


So far i've tested and it works on the Linux debug app. Going to build an android app as well and make sure it works there.

Both PRs are draft at the moment as I make sure it actually works. :-)