### PR TITLE
Assorted minor fixes.

### DIFF
--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -475,6 +475,7 @@ class AppController with ChangeNotifier {
       throw Exception('Notification permissions denied');
     }
 
+    if (!context.mounted) return;
     await UnifiedPush.registerAppWithDialog(context, _selectedAccount, [
       featureAndroidBytesMessage,
     ]);

--- a/lib/src/screens/account/notification/notification_screen.dart
+++ b/lib/src/screens/account/notification/notification_screen.dart
@@ -117,7 +117,7 @@ class _NotificationsScreenState extends State<NotificationsScreen>
                           .putReadAll();
                       _pagingController.refresh();
 
-                      if (!mounted) return;
+                      if (!context.mounted) return;
                       context.read<NotificationCountController>().reload();
                     },
                     label: Text(l(context).notifications_readAll),

--- a/lib/src/screens/explore/community_owner_panel.dart
+++ b/lib/src/screens/explore/community_owner_panel.dart
@@ -185,9 +185,9 @@ class _CommunityOwnerPanelGeneralState
                             widget.data?.isPostingRestrictedToMods)
                 ? null
                 : () async {
+                    final ac = context.read<AppController>();
                     final result = widget.data == null
-                        ? await context
-                              .read<AppController>()
+                        ? await ac
                               .api
                               .communityModeration
                               .create(
@@ -198,8 +198,7 @@ class _CommunityOwnerPanelGeneralState
                                 isPostingRestrictedToMods:
                                     _isPostingRestrictedToMods,
                               )
-                        : await context
-                              .read<AppController>()
+                        : await ac
                               .api
                               .communityModeration
                               .edit(
@@ -267,7 +266,7 @@ class _CommunityOwnerPanelModeratorsState
                           .users
                           .getByName(_addModController.text);
 
-                      if (!mounted) return;
+                      if (!context.mounted) return;
                       final result = await showDialog<DetailedCommunityModel>(
                         context: context,
                         builder: (BuildContext context) => AlertDialog(
@@ -421,7 +420,7 @@ class _CommunityOwnerPanelDeletionState
               );
 
               if (result == true) {
-                if (!mounted) return;
+                if (!context.mounted) return;
                 Navigator.of(context).pop();
               }
             },
@@ -478,7 +477,7 @@ class _CommunityOwnerPanelDeletionDialogState
                       .communityModeration
                       .delete(widget.data.id);
 
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   Navigator.pop(context, true);
                 },
           label: const Text('DELETE COMMUNITY'),

--- a/lib/src/screens/explore/community_screen.dart
+++ b/lib/src/screens/explore/community_screen.dart
@@ -293,7 +293,7 @@ class _CommunityScreenState extends State<CommunityScreen> {
                                       ),
                                     );
 
-                                    if (!mounted) return;
+                                    if (!context.mounted) return;
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       SnackBar(
                                         content: Text(l(context).copied),

--- a/lib/src/screens/explore/user_screen.dart
+++ b/lib/src/screens/explore/user_screen.dart
@@ -318,7 +318,7 @@ class _UserScreenState extends State<UserScreen> {
                                   ),
                                 );
 
-                                if (!mounted) return;
+                                if (!context.mounted) return;
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
                                     content: Text(l(context).copied),

--- a/lib/src/screens/feed/create_screen.dart
+++ b/lib/src/screens/feed/create_screen.dart
@@ -269,7 +269,7 @@ class _CreateScreenState extends State<CreateScreen> {
                         await bodyDraftController.discard();
 
                         // Check BuildContext
-                        if (!mounted) return;
+                        if (!context.mounted) return;
 
                         Navigator.pop(context);
                       },
@@ -302,7 +302,7 @@ class _CreateScreenState extends State<CreateScreen> {
                         );
 
                         // Check BuildContext
-                        if (!mounted) return;
+                        if (!context.mounted) return;
 
                         Navigator.pop(context);
                       },
@@ -337,7 +337,7 @@ class _CreateScreenState extends State<CreateScreen> {
                         await bodyDraftController.discard();
 
                         // Check BuildContext
-                        if (!mounted) return;
+                        if (!context.mounted) return;
 
                         Navigator.pop(context);
                       },
@@ -380,7 +380,7 @@ class _CreateScreenState extends State<CreateScreen> {
                   await bodyDraftController.discard();
 
                   // Check BuildContext
-                  if (!mounted) return;
+                  if (!context.mounted) return;
 
                   Navigator.pop(context);
                 }),

--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -829,7 +829,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
   void getScrollDirection() {
     final direction =
         _scrollController?.position.userScrollDirection ?? ScrollDirection.idle;
-    if (direction != ScrollDirection.idle) {
+    if (direction != ScrollDirection.idle && direction != _scrollDirection) {
       setState(() {
         _scrollDirection = direction;
       });
@@ -840,12 +840,12 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
   bool get wantKeepAlive => true;
 
   Future<(List<PostModel>, String?)> _tryFetchPage(String pageKey) async {
+    final ac = context.read<AppController>();
     List<PostModel> newItems;
     String? nextPageKey;
     switch (widget.view) {
       case FeedView.threads:
-        final postListModel = await context
-            .read<AppController>()
+        final postListModel = await ac
             .api
             .threads
             .list(
@@ -855,10 +855,9 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
               sort: widget.sort,
               usePreferredLangs: whenLoggedIn(
                 context,
-                context.read<AppController>().profile.useAccountLanguageFilter,
+                ac.profile.useAccountLanguageFilter,
               ),
-              langs: context
-                  .read<AppController>()
+              langs: ac
                   .profile
                   .customLanguageFilter
                   .toList(),
@@ -870,8 +869,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
         break;
 
       case FeedView.microblog:
-        final postListModel = await context
-            .read<AppController>()
+        final postListModel = await ac
             .api
             .microblogs
             .list(
@@ -881,10 +879,9 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
               sort: widget.sort,
               usePreferredLangs: whenLoggedIn(
                 context,
-                context.read<AppController>().profile.useAccountLanguageFilter,
+                ac.profile.useAccountLanguageFilter,
               ),
-              langs: context
-                  .read<AppController>()
+              langs: ac
                   .profile
                   .customLanguageFilter
                   .toList(),
@@ -896,23 +893,21 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
         break;
 
       case FeedView.timeline:
-        final threadsFuture = context.read<AppController>().api.threads.list(
+        final threadsFuture = ac.api.threads.list(
           widget.source,
           sourceId: widget.sourceId,
           page: nullIfEmpty(pageKey),
           sort: FeedSort.newest,
           usePreferredLangs: whenLoggedIn(
             context,
-            context.read<AppController>().profile.useAccountLanguageFilter,
+            ac.profile.useAccountLanguageFilter,
           ),
-          langs: context
-              .read<AppController>()
+          langs: ac
               .profile
               .customLanguageFilter
               .toList(),
         );
-        final microblogFuture = context
-            .read<AppController>()
+        final microblogFuture = ac
             .api
             .microblogs
             .list(
@@ -922,10 +917,9 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
               sort: FeedSort.newest,
               usePreferredLangs: whenLoggedIn(
                 context,
-                context.read<AppController>().profile.useAccountLanguageFilter,
+                ac.profile.useAccountLanguageFilter,
               ),
-              langs: context
-                  .read<AppController>()
+              langs: ac
                   .profile
                   .customLanguageFilter
                   .toList(),
@@ -987,8 +981,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
     // Prevent duplicates
     final currentItemIds =
         _pagingController.itemList?.map((post) => (post.type, post.id)) ?? [];
-    final filterListActivations = context
-        .read<AppController>()
+    final filterListActivations = ac
         .profile
         .filterLists;
     final items = newItems
@@ -1022,8 +1015,6 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
           return true;
         })
         .toList();
-
-    final ac = context.read<AppController>();
 
     final finalItems =
         ac.serverSoftware == ServerSoftware.lemmy && ac.isLoggedIn
@@ -1142,7 +1133,8 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                       initData: item,
                       onUpdate: (newValue) {
                         var newList = _pagingController.itemList;
-                        newList![index] = newValue;
+                        if (newList == null) return;
+                        newList[index] = newValue;
                         setState(() {
                           _pagingController.itemList = newList;
                         });
@@ -1228,7 +1220,8 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                                 item,
                                 (newValue) {
                                   var newList = _pagingController.itemList;
-                                  newList![index] = newValue;
+                                  if (newList == null) return;
+                                  newList[index] = newValue;
                                   setState(() {
                                     _pagingController.itemList = newList;
                                   });
@@ -1272,7 +1265,8 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
                             item,
                             (newValue) {
                               var newList = _pagingController.itemList;
-                              newList![index] = newValue;
+                              if (newList == null) return;
+                              newList[index] = newValue;
                               setState(() {
                                 _pagingController.itemList = newList;
                               });

--- a/lib/src/screens/feed/post_comment.dart
+++ b/lib/src/screens/feed/post_comment.dart
@@ -236,7 +236,7 @@ class _PostCommentState extends State<PostComment> {
                 widget.comment.id,
               );
 
-              if (!mounted) return;
+              if (!context.mounted) return;
 
               widget.onUpdate(
                 widget.comment.copyWith(

--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -77,6 +77,7 @@ class _PostPageState extends State<PostPage> {
   }
 
   void _onUpdate(PostModel newValue) {
+    if (!mounted) return;
     setState(() {
       _data = newValue;
     });

--- a/lib/src/screens/settings/login_confirm.dart
+++ b/lib/src/screens/settings/login_confirm.dart
@@ -154,7 +154,7 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
                           ).users.getMe();
 
                           // Check BuildContext
-                          if (!mounted) return;
+                          if (!context.mounted) return;
                           context.read<AppController>().setAccount(
                             '${user.name}@${widget.server}',
                             Account(jwt: response.bodyJson['jwt'] as String),
@@ -188,7 +188,7 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
                           );
 
                           // Check BuildContext
-                          if (!mounted) return;
+                          if (!context.mounted) return;
 
                           Map<String, String>? result = await Navigator.push(
                             context,
@@ -221,7 +221,7 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
                           ).users.getMe();
 
                           // Check BuildContext
-                          if (!mounted) return;
+                          if (!context.mounted) return;
 
                           context.read<AppController>().setAccount(
                             '${user.name}@${widget.server}',

--- a/lib/src/screens/settings/profile_selection.dart
+++ b/lib/src/screens/settings/profile_selection.dart
@@ -139,7 +139,7 @@ class _ProfileSelectWidgetState extends State<_ProfileSelectWidget> {
                               payload: profile.toJson(),
                             );
 
-                            if (!mounted) return;
+                            if (!context.mounted) return;
                             String communityName = mbinConfigsCommunityName;
                             if (communityName.endsWith(
                               context.read<AppController>().instanceHost,

--- a/lib/src/widgets/ban_dialog.dart
+++ b/lib/src/widgets/ban_dialog.dart
@@ -71,7 +71,7 @@ class _BanDialogState extends State<BanDialog> {
                         reason: _reasonTextEditingController.text,
                       );
 
-                  if (!mounted) return;
+                  if (!context.mounted) return;
                   Navigator.of(context).pop();
                 },
           label: Text(l(context).banUserX(widget.user.name)),

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -193,35 +193,37 @@ class _ContentItemState extends State<ContentItem> {
 
   @override
   Widget build(BuildContext context) {
-    return Wrapper(
-      shouldWrap: widget.onClick != null,
-      parentBuilder: (child) {
-        return InkWell(
-          onTap: widget.onClick,
-          onLongPress: () => showContentMenu(
-            context,
-            widget,
-            onTranslate: widget.onTranslate,
-            onReply: widget.onReply != null
-                ? () => setState(() {
-                    _replyTextController = TextEditingController();
-                  })
-                : () {},
-          ),
-          onSecondaryTap: () => showContentMenu(
-            context,
-            widget,
-            onTranslate: widget.onTranslate,
-            onReply: widget.onReply != null
-                ? () => setState(() {
-                    _replyTextController = TextEditingController();
-                  })
-                : () {},
-          ),
-          child: child,
-        );
-      },
-      child: widget.isCompact ? compact() : full(),
+    return RepaintBoundary(
+      child: Wrapper(
+        shouldWrap: widget.onClick != null,
+        parentBuilder: (child) {
+          return InkWell(
+            onTap: widget.onClick,
+            onLongPress: () => showContentMenu(
+              context,
+              widget,
+              onTranslate: widget.onTranslate,
+              onReply: widget.onReply != null
+                  ? () => setState(() {
+                      _replyTextController = TextEditingController();
+                    })
+                  : () {},
+            ),
+            onSecondaryTap: () => showContentMenu(
+              context,
+              widget,
+              onTranslate: widget.onTranslate,
+              onReply: widget.onReply != null
+                  ? () => setState(() {
+                      _replyTextController = TextEditingController();
+                    })
+                  : () {},
+            ),
+            child: child,
+          );
+        },
+        child: widget.isCompact ? compact() : full(),
+      )
     );
   }
 

--- a/lib/src/widgets/markdown/markdown_editor.dart
+++ b/lib/src/widgets/markdown/markdown_editor.dart
@@ -972,8 +972,9 @@ class _MarkdownEditorConfigShareDialogState
   }
 
   void loadNames() async {
-    _profiles = await context.read<AppController>().getProfileNames();
-    _filterLists = context.read<AppController>().filterLists.keys.toList();
+    final ac = context.read<AppController>();
+    _profiles = await ac.getProfileNames();
+    _filterLists = ac.filterLists.keys.toList();
     setState(() {});
   }
 
@@ -999,6 +1000,7 @@ class _MarkdownEditorConfigShareDialogState
                   name: profileName,
                   payload: profile.toJson(),
                 );
+                if (!context.mounted) return;
                 Navigator.pop(context, config.toMarkdown());
               },
             ),
@@ -1023,6 +1025,7 @@ class _MarkdownEditorConfigShareDialogState
                   payload: filterList.toJson(),
                 );
                 final configStr = jsonEncode(config.toJson());
+                if (!context.mounted) return;
                 Navigator.pop(context, configStr);
               },
             ),


### PR DESCRIPTION
Mostly changing some `if (!mounted)` to `if (!context.mounted)` as suggested by dart analysis.

Added check for `direction != _scrollDirection` in feed screen getScrollDirection. Without this it was triggering rebuilds whenever the screen was scrolled. I can't really see a difference but there was a user who had stuttering when they scrolled so maybe this will help a little.

Also wrapped content item in a `RepaintBoundary`. This should prevent changes in the wrapped item from causing repaints in the rest of the feed.

Added a null check and a check for mounted context to post items onUpdate callback. Found a null access bug when voting on a post then quickly exiting the page.