### PR TITLE
Fix navigate to reply from lemmy notification.

### DIFF
--- a/lib/src/api/comments.dart
+++ b/lib/src/api/comments.dart
@@ -190,7 +190,10 @@ class APIComments {
 
       case ServerSoftware.lemmy:
         const path = '/comment/list';
-        final query = {'parent_id': commentId.toString()};
+        final query = {
+          'parent_id': commentId.toString(),
+          'type_': 'All',
+        };
 
         final response = await client.get(path, queryParams: query);
 


### PR DESCRIPTION
This ensures federated comments are also fetched when getting a comment from lemmy.
Closes #303.