### PR TITLE
Early exit if state is not mounted.

### DIFF
--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -69,6 +69,7 @@ class _PostPageState extends State<PostPage> {
           widget.postId ?? _data!.id,
         ),
       };
+      if (!mounted) return;
       setState(() {
         _data = newPost;
       });


### PR DESCRIPTION
Fixes `setState() called after dispose()` error when opening then closing a post quickly.