### PR TITLE
Fix several mod actions for piefed.

### DIFF
--- a/lib/src/api/community_moderation.dart
+++ b/lib/src/api/community_moderation.dart
@@ -116,7 +116,8 @@ class APICommunityModeration {
           'community_id': communityId,
           'user_id': userId,
           'reason': reason,
-          'expires_at': expiredAt?.toIso8601String(),
+          if (expiredAt != null)
+            'expires_at': expiredAt.toIso8601String(),
         };
 
         final response = await client.post(path, body: body);

--- a/lib/src/api/moderation.dart
+++ b/lib/src/api/moderation.dart
@@ -15,7 +15,7 @@ class APIModeration {
 
   APIModeration(this.client);
 
-  Future<PostModel> postPin(PostType postType, int postId) async {
+  Future<PostModel> postPin(PostType postType, int postId, bool pinned) async {
     switch (client.software) {
       case ServerSoftware.mbin:
         final path = '/moderate/${_postTypeMbin[postType]}/$postId/pin';
@@ -37,13 +37,13 @@ class APIModeration {
           path,
           body: {
             'post_id': postId,
-            'featured': true,
+            'featured': pinned,
             'feature_type': 'Community',
           },
         );
 
         return PostModel.fromPiefed(
-          response.bodyJson['post_view'] as JsonMap,
+          response.bodyJson,
           langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }
@@ -111,7 +111,7 @@ class APIModeration {
         );
 
         return PostModel.fromPiefed(
-          response.bodyJson['post_view'] as JsonMap,
+          response.bodyJson,
           langCodeIdPairs: await client.languageCodeIdPairs(),
         );
     }

--- a/lib/src/models/post.dart
+++ b/lib/src/models/post.dart
@@ -260,7 +260,7 @@ abstract class PostModel with _$PostModel {
     JsonMap json, {
     required List<(String, int)> langCodeIdPairs,
   }) {
-    final postView = json['post_view'] as JsonMap;
+    final postView = json['post_view'] as JsonMap? ?? json;
     final piefedPost = postView['post'] as JsonMap;
     final piefedCounts = postView['counts'] as JsonMap;
 

--- a/lib/src/screens/feed/post_item.dart
+++ b/lib/src/screens/feed/post_item.dart
@@ -204,6 +204,7 @@ class _PostItemState extends State<PostItem> {
                     await ac.api.moderation.postPin(
                       widget.item.type,
                       widget.item.id,
+                      !widget.item.isPinned,
                     ),
                   );
                 },

--- a/lib/src/screens/feed/post_page.dart
+++ b/lib/src/screens/feed/post_page.dart
@@ -178,7 +178,11 @@ class _PostPageState extends State<PostPage> {
           ? null
           : () async {
               _updateCrossPost(
-                await ac.api.moderation.postPin(crossPost.type, crossPost.id),
+                await ac.api.moderation.postPin(
+                  crossPost.type,
+                  crossPost.id,
+                  !crossPost.isPinned,
+                ),
               );
             },
       onModerateMarkNSFW: !canModerate


### PR DESCRIPTION
A couple small fixes to the piefed mod actions.
- Fix incorrectly parsing response from pin post and delete post
- Add parameter whether a post should be pinned or unpinned.
- Fix ban user parameter expires_at not being allowed to be null.