### PR TITLE
Fix next page key not being passed to the paging controller.

### DIFF
--- a/lib/src/screens/feed/feed_screen.dart
+++ b/lib/src/screens/feed/feed_screen.dart
@@ -714,7 +714,7 @@ class _FeedScreenBodyState extends State<FeedScreenBody>
           setState(() {
             _lastPageFilteredOut = newItems.isEmpty && nextPageKey != null;
           });
-          return (newItems, newItems.isEmpty ? null : nextPageKey);
+          return (newItems, nextPageKey);
         },
       );
   SubordinateScrollController? _scrollController;


### PR DESCRIPTION
Paging controller manages page keys so doing the check for empty page here confuses it.
Fixes #319 