### PR TITLE
Fix accessing state in initState when not mounted.

### DIFF
--- a/lib/src/screens/explore/community_screen.dart
+++ b/lib/src/screens/explore/community_screen.dart
@@ -49,9 +49,12 @@ class _CommunityScreenState extends State<CommunityScreen> {
           .community
           .get(widget.communityId)
           .then(
-            (value) => setState(() {
-              _data = value;
-            }),
+            (value) {
+              if (!mounted) return;
+              setState(() {
+                _data = value;
+              });
+            }
           );
     }
   }

--- a/lib/src/screens/explore/domain_screen.dart
+++ b/lib/src/screens/explore/domain_screen.dart
@@ -37,9 +37,12 @@ class _DomainScreenState extends State<DomainScreen> {
           .domains
           .get(widget.domainId)
           .then(
-            (value) => setState(() {
-              _data = value;
-            }),
+            (value) {
+              if (!mounted) return;
+              setState(() {
+                _data = value;
+              });
+            }
           );
     }
   }

--- a/lib/src/screens/explore/user_screen.dart
+++ b/lib/src/screens/explore/user_screen.dart
@@ -82,9 +82,12 @@ class _UserScreenState extends State<UserScreen> {
             return value.copyWith(tags: [...value.tags, ...tags]);
           })
           .then(
-            (value) => setState(() {
-              _data = value;
-            }),
+            (value) {
+              if (!mounted) return;
+              setState(() {
+                _data = value;
+              });
+            }
           );
     }
   }

--- a/lib/src/screens/feed/post_comment_screen.dart
+++ b/lib/src/screens/feed/post_comment_screen.dart
@@ -37,9 +37,12 @@ class _PostCommentScreenState extends State<PostCommentScreen> {
         .comments
         .get(widget.postType, widget.commentId)
         .then(
-          (value) => setState(() {
-            _comment = value;
-          }),
+          (value) {
+            if (!mounted) return;
+            setState(() {
+              _comment = value;
+            });
+          }
         );
   }
 

--- a/lib/src/widgets/content_item/content_item.dart
+++ b/lib/src/widgets/content_item/content_item.dart
@@ -205,9 +205,12 @@ class _ContentItemState extends State<ContentItem> {
           .read<AppController>()
           .getUserTags(widget.user!.name)
           .then(
-            (tags) => setState(() {
-              _userTags = [...widget.user!.tags, ...tags];
-            }),
+            (tags) {
+              if (!mounted) return;
+              setState(() {
+                _userTags = [...widget.user!.tags, ...tags];
+              });
+            }
           );
     }
   }


### PR DESCRIPTION
Add mounted checks in `initState` in case of instances when widget is scrolled out of view before async function returns.
Shouldn't need to add checks for setting state in button callbacks etc since its unlikely for the associated widget to be unmounted before the callback is completed.

Came across this after pressing 'Back to top' from far down on a feed. The quick scrolling resulted in a lot of null check operator errors.