### PR TITLE
Fix markdown editor textinput area.

### DIFF
--- a/lib/src/widgets/markdown/markdown_editor.dart
+++ b/lib/src/widgets/markdown/markdown_editor.dart
@@ -238,8 +238,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
                                   ),
                                 ),
                                 const Divider(height: 1, thickness: 1),
-                                Flexible(
-                                  fit: FlexFit.loose,
+                                Expanded(
                                   child: CallbackShortcuts(
                                     bindings: <ShortcutActivator, VoidCallback>{
                                       const SingleActivator(


### PR DESCRIPTION
The text input in the markdown editor didn't cover the entire visible box. Switching to Expanded should let it fill the available area.