### PR TITLE
Fix scroll broken in comments tab for piefed/lemmy.

### DIFF
--- a/lib/src/screens/explore/user_screen.dart
+++ b/lib/src/screens/explore/user_screen.dart
@@ -448,7 +448,9 @@ class _UserScreenState extends State<UserScreen> {
                       mode: UserFeedType.comment,
                       sort: _sort,
                       data: _data,
-                      isActive: controller.index == 2,
+                      isActive: ac.serverSoftware == ServerSoftware.mbin
+                          ? controller.index == 2
+                          : controller.index == 1,
                     ),
                     if (ac.serverSoftware == ServerSoftware.mbin)
                       UserScreenBody(


### PR DESCRIPTION
Was using wrong index to check whether a tabs scroll controller is active.
Fixes #338 