### PR TITLE
Image page always uses BoxFit.contain.

### DIFF
--- a/lib/src/widgets/image.dart
+++ b/lib/src/widgets/image.dart
@@ -57,7 +57,7 @@ class AdvancedImage extends StatelessWidget {
               image,
               title: openTitle!,
               hero: tag,
-              fit: fit,
+              fit: BoxFit.contain,
             ),
           ),
           child: child,


### PR DESCRIPTION
As reported on matrix when opening very tall images the top and bottom may be cutoff.
This should fix that however the hero animation will be broken when the "Full image size" settings are disabled as it will be transitioning `BoxFit.fitWidth` -> `BoxFit.contain`. When the "Full image size" settings are enabled or when opening a thumbnail the animation should be fine as there is no change in image fit.

I'll keep looking for a way to have both but in the meantime I think being able to see the full image is more important than the animation.