### PR TITLE
Fix Linux gtk header bar always being used on Wayland

### DIFF
--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -20,32 +20,7 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "Interstellar");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "Interstellar");
-  }
+  gtk_window_set_title(window, "Interstellar");
 
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));


### PR DESCRIPTION
Fixes https://github.com/interstellar-app/interstellar/issues/158.

Related to https://github.com/flutter/flutter/issues/111453 https://github.com/AppFlowy-IO/AppFlowy/pull/5991 https://github.com/krille-chan/fluffychat/issues/1628 https://github.com/localsend/localsend/pull/2360.

<table>
<tr>
 <td> 
Before
 <td>
After
<tr>
 <td>
<img width="2740" height="1716" alt="image" src="https://github.com/user-attachments/assets/05d403c9-4c6d-47af-aec9-985ce729d4df" />
 <td>
<img width="2820" height="1756" alt="image" src="https://github.com/user-attachments/assets/2a387d75-364d-4888-817a-63cd4ec530ae" />
</table>