### PR TITLE
Set min window size to be 1/16 of available size.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -27,9 +28,14 @@ void main() async {
   if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
     await windowManager.ensureInitialized();
 
-    WindowOptions windowOptions = const WindowOptions(
-      minimumSize: Size(400, 400),
-    );
+    // Get smallest dimensions of available displays and set minimum window
+    // size to be a 16th of those dimensions.
+    final screenSize = PlatformDispatcher.instance.displays
+        .map((display) => display.size)
+        .reduce((a, b) => Size(min(a.width, b.width), min(a.height, b.height)));
+    final minWindowSize = screenSize / 4;
+
+    WindowOptions windowOptions = WindowOptions(minimumSize: minWindowSize);
 
     windowManager.waitUntilReadyToShow(windowOptions, () async {
       await windowManager.show();


### PR DESCRIPTION
This gets the smallest dimensions of the available screens and sets the minimum window size to a 16th of those dimensions. 
On my 2560x1440 monitor it sets the min window size to (640, 360).
Fixes #157 