### PR TITLE
Remove incorrect check for empty accounts.

### DIFF
--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -607,8 +607,7 @@ class AppController with ChangeNotifier {
     // Ensure default guest account remains
     if (_servers.isEmpty ||
         _accounts.isEmpty ||
-        _selectedAccount.isEmpty ||
-        _accounts.length == 1) {
+        _selectedAccount.isEmpty) {
       await saveServer(ServerSoftware.mbin, 'kbin.earth');
       await setAccount(
         '@kbin.earth',


### PR DESCRIPTION
I can't remember where the `_accounts.length == 1` came from but it results in there always being at least 2 accounts registered. The account chosen by the user and the default guest account. We instead want there to always be at least 1 account registered which is handled by the checks for empty.
Fixes #354 