### PR TITLE
Remove Archive.today from alternate links

### DIFF
--- a/lib/src/widgets/content_item/content_item_link_panel.dart
+++ b/lib/src/widgets/content_item/content_item_link_panel.dart
@@ -15,7 +15,6 @@ class _LinkAltSource {
 
 const _linkAltSources = [
   _LinkAltSource(name: '12ft.io', urlPrefix: 'https://12ft.io/proxy?q='),
-  _LinkAltSource(name: 'Archive Today', urlPrefix: 'https://archive.ph/'),
   _LinkAltSource(
     name: 'Ghost Archive',
     urlPrefix: 'https://ghostarchive.org/search?term=',


### PR DESCRIPTION
Archive.today is purposefully DDOSing someone's personal blog site and is tampering with web snapshots. It is now blacklisted from Wikipedia.

- https://arstechnica.com/tech-policy/2026/02/wikipedia-bans-archive-today-after-site-executed-ddos-and-altered-web-captures/
- https://www.pcmag.com/news/wikipedia-blacklists-archiveis-after-alleged-ddos-attack-on-blogger
- https://gyrovague.com/2026/02/01/archive-today-is-directing-a-ddos-attack-against-my-blog/

[From Wikipedia itself:](https://en.wikipedia.org/wiki/Wikipedia:Requests_for_comment/Archive.is_RFC_5)

> In January 2026, the maintainers of Archive.today [inserted malicious code](https://gyrovague.com/2026/02/01/archive-today-is-directing-a-ddos-attack-against-my-blog/) in order to perform a distributed denial of service attack against a person they were in dispute with. Every time a user encounters the CAPTCHA page, their internet connection is used to attack a certain individual's blog. This obviously raises significant concerns for readers' safety, as well as the long-term stability and integrity of the service. The JavaScript code which causes this is still live on the website. However, a significant amount of people also think that mass-removing links to Archive.today may harm verifiability, and that the service is harder to censor than certain other archiving sites. [As of 19 February 2026](https://web.archive.org/web/20260219054559/https://archive.ph/), the malicious code remains active. It is highly recommended not to visit the archive without blocking network requests to gyrovague.com to avoid being part of the attack.