### PR TITLE
Refactor ServerClient to handle MultipartRequests

### DIFF
--- a/lib/src/api/client.dart
+++ b/lib/src/api/client.dart
@@ -2,8 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:interstellar/src/controller/server.dart';
 import 'package:interstellar/src/utils/utils.dart';
+import 'package:mime/mime.dart';
+import 'package:path/path.dart';
 
 class RestrictedAuthException implements Exception {
   RestrictedAuthException(this.message, this.uri);
@@ -77,22 +81,45 @@ class ServerClient {
   Future<http.Response> postMultipart(
     String path, {
     Map<String, String?>? queryParams,
-    FutureOr<void> Function(http.MultipartRequest request)? builder,
-  }) =>
-      _sendMultipart('POST', path, queryParams: queryParams, builder: builder);
+    Map<String, String>? fields,
+    Map<String, XFile>? files,
+  }) => _sendMultipart(
+    'POST',
+    path,
+    queryParams: queryParams,
+    fields: fields,
+    files: files,
+  );
 
   Future<http.Response> _sendMultipart(
     String method,
     String path, {
     Map<String, String?>? queryParams,
-    FutureOr<void> Function(http.MultipartRequest request)? builder,
+    Map<String, String>? fields,
+    Map<String, XFile>? files,
   }) async {
     final request = http.MultipartRequest(
       method,
       _uri(path, queryParams: queryParams),
     );
 
-    await builder?.call(request);
+    if (fields != null) request.fields.addAll(fields);
+    for (final entry in (files ?? {}).entries) {
+      final name = entry.key;
+      final file = entry.value;
+
+      final filename = basename(file.path);
+      final mime = lookupMimeType(filename);
+
+      request.files.add(
+        http.MultipartFile.fromBytes(
+          name,
+          await file.readAsBytes(),
+          filename: filename,
+          contentType: mime == null ? null : MediaType.parse(mime),
+        ),
+      );
+    }
 
     return _sendRequest(request);
   }

--- a/lib/src/api/comments.dart
+++ b/lib/src/api/comments.dart
@@ -301,19 +301,13 @@ class APIComments {
 
           final response = await client.postMultipart(
             path,
-            builder: (request) async {
-              final file = http.MultipartFile.fromBytes(
-                'uploadImage',
-                await image.readAsBytes(),
-                filename: basename(image.path),
-                contentType: MediaType.parse(lookupMimeType(image.path)!),
-              );
-              request.files.add(file);
-              request.fields['body'] = body;
-              request.fields['lang'] = lang;
-              request.fields['isAdult'] = isAdult.toString();
-              request.fields['alt'] = alt ?? '';
+            fields: {
+              'body': body,
+              'lang': lang,
+              'isAdult': isAdult.toString(),
+              'alt': alt ?? '',
             },
+            files: {'uploadImage': image},
           );
 
           return CommentModel.fromMbin(response.bodyJson);

--- a/lib/src/api/images.dart
+++ b/lib/src/api/images.dart
@@ -38,15 +38,7 @@ class APIImages {
 
               final response = await client.postMultipart(
                 path,
-                builder: (request) async {
-                  final file = http.MultipartFile.fromBytes(
-                    'images[]',
-                    await image.readAsBytes(),
-                    filename: basename(image.path),
-                    contentType: MediaType.parse(lookupMimeType(image.path)!),
-                  );
-                  request.files.add(file);
-                },
+                files: {'images[]': image},
               );
 
               final imageName =
@@ -61,15 +53,7 @@ class APIImages {
 
               final response = await client.postMultipart(
                 path,
-                builder: (request) async {
-                  final file = http.MultipartFile.fromBytes(
-                    'file',
-                    await image.readAsBytes(),
-                    filename: basename(image.path),
-                    contentType: MediaType.parse(lookupMimeType(image.path)!),
-                  );
-                  request.files.add(file);
-                },
+                files: {'file': image},
               );
 
               return response.bodyJson['url']! as String;

--- a/lib/src/api/microblogs.dart
+++ b/lib/src/api/microblogs.dart
@@ -118,19 +118,13 @@ class MbinAPIMicroblogs {
 
     final response = await client.postMultipart(
       path,
-      builder: (request) async {
-        final multipartFile = http.MultipartFile.fromBytes(
-          'uploadImage',
-          await image.readAsBytes(),
-          filename: image.name,
-          contentType: MediaType.parse(image.mimeType!),
-        );
-        request.files.add(multipartFile);
-        request.fields['body'] = body;
-        request.fields['lang'] = lang;
-        request.fields['isAdult'] = isAdult.toString();
-        request.fields['alt'] = alt;
+      fields: {
+        'body': body,
+        'lang': lang,
+        'isAdult': isAdult.toString(),
+        'alt': alt,
       },
+      files: {'uploadImage': image},
     );
 
     return PostModel.fromMbinPost(response.bodyJson);

--- a/lib/src/api/threads.dart
+++ b/lib/src/api/threads.dart
@@ -396,35 +396,17 @@ class APIThreads {
 
         final response = await client.postMultipart(
           path,
-          builder: (request) async {
-            request.fields['title'] = title;
-            if (url != null) {
-              request.fields['url'] = url;
-            }
-            for (var i = 0; i < tags.length; ++i) {
-              request.fields['tags[$i]'] = tags[i];
-            }
-            request.fields['isOc'] = isOc.toString();
-            if (body != null && body.isNotEmpty) {
-              request.fields['body'] = body;
-            }
-            request.fields['lang'] = lang;
-            request.fields['isAdult'] = isAdult.toString();
-            if (alt != null) {
-              request.fields['alt'] = alt;
-            }
-            if (image != null) {
-              final file = http.MultipartFile.fromBytes(
-                'uploadImage',
-                await image.readAsBytes(),
-                filename: image.name,
-                contentType: MediaType.parse(
-                  image.mimeType ?? lookupMimeType(image.path)!,
-                ),
-              );
-              request.files.add(file);
-            }
+          fields: {
+            'title': title,
+            'url': ?url,
+            for (var i = 0; i < tags.length; ++i) 'tags[$i]': tags[i],
+            'isOc': isOc.toString(),
+            if (body != null && body.isNotEmpty) 'body': body,
+            'lang': lang,
+            'isAdult': isAdult.toString(),
+            'alt': ?alt,
           },
+          files: {'uploadImage': ?image},
         );
 
         return PostModel.fromMbinEntry(response.bodyJson);
@@ -435,17 +417,7 @@ class APIThreads {
 
           final pictrsResponse = await client.postMultipart(
             uploadPath,
-            builder: (request) async {
-              final multipartFile = http.MultipartFile.fromBytes(
-                'images[]',
-                await image.readAsBytes(),
-                filename: image.name,
-                contentType: MediaType.parse(
-                  image.mimeType ?? lookupMimeType(image.path)!,
-                ),
-              );
-              request.files.add(multipartFile);
-            },
+            files: {'images[]': image},
           );
 
           final imageName =
@@ -481,17 +453,7 @@ class APIThreads {
 
           final uploadResponse = await client.postMultipart(
             uploadPath,
-            builder: (request) async {
-              final multipartFile = http.MultipartFile.fromBytes(
-                'file',
-                await image.readAsBytes(),
-                filename: image.name,
-                contentType: MediaType.parse(
-                  image.mimeType ?? lookupMimeType(image.path)!,
-                ),
-              );
-              request.files.add(multipartFile);
-            },
+            files: {'file': image},
           );
 
           final imageUrl = uploadResponse.bodyJson['url'] as String?;

--- a/lib/src/api/users.dart
+++ b/lib/src/api/users.dart
@@ -272,15 +272,7 @@ class APIUsers {
 
         final response = await client.postMultipart(
           path,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'uploadImage',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'uploadImage': image},
         );
 
         return DetailedUserModel.fromMbin(response.bodyJson);
@@ -290,15 +282,7 @@ class APIUsers {
 
         final pictrsResponse = await client.postMultipart(
           pictrsPath,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'images[]',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'images[]': image},
         );
 
         final imageName =
@@ -320,15 +304,7 @@ class APIUsers {
 
         final uploadResponse = await client.postMultipart(
           uploadPath,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'file',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'file': image},
         );
 
         final imageUrl = uploadResponse.bodyJson['url'] as String?;
@@ -372,15 +348,7 @@ class APIUsers {
 
         final response = await client.postMultipart(
           path,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'uploadImage',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'uploadImage': image},
         );
 
         return DetailedUserModel.fromMbin(response.bodyJson);
@@ -390,15 +358,7 @@ class APIUsers {
 
         final pictrsResponse = await client.postMultipart(
           pictrsPath,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'images[]',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'images[]': image},
         );
 
         final imageName =
@@ -420,15 +380,7 @@ class APIUsers {
 
         final uploadResponse = await client.postMultipart(
           uploadPath,
-          builder: (request) async {
-            final multipartFile = http.MultipartFile.fromBytes(
-              'file',
-              await image.readAsBytes(),
-              filename: basename(image.path),
-              contentType: MediaType.parse(lookupMimeType(image.path)!),
-            );
-            request.files.add(multipartFile);
-          },
+          files: {'file': image},
         );
 
         final imageUrl = uploadResponse.bodyJson['url'] as String?;


### PR DESCRIPTION
- Create a new method in `ServerClient`, `postMultipart` which contains properties for `fields` (map of `String`s) and `files` (map of `XFile`s).
- Remove unnecessary `headers` argument from existing methods. It was only used to specify a JSON content type, which is done automatically when `body` is provided.
- Stop using ServerClient's HTTP client for external requests, as that passes them authentication headers, and would essentially give them full access to the signed-in account if they knew what to do with it. Let's just hope neither image hosting service is malicious.