### PR TITLE
Enable legacy packaging for Android to reduce APK size

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -72,6 +72,12 @@ android {
         includeInApk = false
         includeInBundle = false
     }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
 }
 
 flutter {


### PR DESCRIPTION
Closes #205.

With legacy packaging enabled, the size of the APK file is dropped by an average of 48%. For `arm64`, it goes from `51.2MB` to `25.0MB`.

Before:

```
✓ Built build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk (48.8MB)
✓ Built build/app/outputs/flutter-apk/app-arm64-v8a-release.apk (51.2MB)
✓ Built build/app/outputs/flutter-apk/app-x86_64-release.apk (56.7MB)
```

After:

```
✓ Built build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk (24.7MB)
✓ Built build/app/outputs/flutter-apk/app-arm64-v8a-release.apk (25.0MB)
✓ Built build/app/outputs/flutter-apk/app-x86_64-release.apk (26.1MB)
```