### PR TITLE
Misc fixes.

### DIFF
--- a/lib/src/controller/router.dart
+++ b/lib/src/controller/router.dart
@@ -29,19 +29,41 @@ class AppRouter extends RootStackRouter {
 
         AutoRoute(page: FeedRoute.page, path: 'f/:feedName'),
 
-        AutoRoute(page: ThreadRoute.page, path: 'c/:communityName/thread/:id'),
+        AutoRoute(
+          page: ThreadRoute.page,
+          path: 'c/:communityName/thread/:id',
+          restorationId: (route) =>
+              '${route.name}-${route.pathParams.get('id')}',
+        ),
         AutoRoute(
           page: MicroblogRoute.page,
           path: 'c/:communityName/microblog/:id',
+          restorationId: (route) =>
+              '${route.name}-${route.pathParams.get('id')}',
         ),
-        AutoRoute(page: PostCommentRoute.page, path: 'comment/:id'),
+        AutoRoute(
+          page: PostCommentRoute.page,
+          path: 'comment/:id',
+          restorationId: (route) =>
+              '${route.name}-${route.pathParams.get('id')}',
+        ),
         AutoRoute(page: ContentReplyRoute.page, path: 'reply'),
 
-        AutoRoute(page: UserRoute.page, path: 'u/:username'),
+        AutoRoute(
+          page: UserRoute.page,
+          path: 'u/:username',
+          restorationId: (route) =>
+              '${route.name}-${route.pathParams.get('username')}',
+        ),
         AutoRoute(page: ModLogUserRoute.page, path: 'u/:username/modlog'),
         AutoRoute(page: MessageThreadRoute.page, path: 'u/:username/message'),
 
-        AutoRoute(page: CommunityRoute.page, path: 'c/:communityName'),
+        AutoRoute(
+          page: CommunityRoute.page,
+          path: 'c/:communityName',
+          restorationId: (route) =>
+              '${route.name}-${route.pathParams.get('communityName')}',
+        ),
         AutoRoute(
           page: ModLogCommunityRoute.page,
           path: 'c/:communityName/modlog',

--- a/lib/src/models/modlog.dart
+++ b/lib/src/models/modlog.dart
@@ -67,9 +67,9 @@ abstract class ModlogItemModel with _$ModlogItemModel {
         ModLogType.postPinned => null,
         ModLogType.postUnpinned => null,
         ModLogType.microblogPostDeleted =>
-          (json['subject']! as JsonMap)['body']! as String,
+          (json['subject']! as JsonMap)['body'] as String?,
         ModLogType.microblogPostRestored =>
-          (json['subject']! as JsonMap)['body']! as String,
+          (json['subject']! as JsonMap)['body'] as String?,
         ModLogType.microblogCommentDeleted => null,
         ModLogType.microblogCommentRestored => null,
         ModLogType.ban => null,


### PR DESCRIPTION
- Modlog null error when microblog body is null.
- Fix multiple routes of same type on stack. E.g. opening a community from a mention in another community description results in two community routes in the navigation stack. This uses the route params to disambiguate them.