### PR TITLE
Truncate entered password to match lemmy/piefed limits.

### DIFF
--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -473,7 +473,10 @@ class AppController with ChangeNotifier {
               ServerSoftware.piefed => 'username',
               ServerSoftware.mbin => throw UnreachableError(),
             }: username,
-            'password': password,
+            'password': password?.substring(
+              0,
+              software == ServerSoftware.lemmy ? 60 : 128,
+            ),
             if (software == ServerSoftware.lemmy) 'totp_2fa_token': totp,
           }),
         );

--- a/lib/src/screens/settings/login_confirm.dart
+++ b/lib/src/screens/settings/login_confirm.dart
@@ -52,6 +52,7 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
               padding: const EdgeInsets.all(16),
               child: AutofillGroup(
                 child: Column(
+                  spacing: 12,
                   children: [
                     TextEditor(
                       _usernameEmailTextController,
@@ -63,13 +64,14 @@ class _LoginConfirmScreenState extends State<LoginConfirmScreen> {
                         AutofillHints.email,
                       ],
                     ),
-                    const SizedBox(height: 12),
                     PasswordEditor(
                       _passwordTextController,
                       onChanged: (_) => setState(() {}),
+                      maxLength: widget.software == ServerSoftware.lemmy
+                          ? 60
+                          : 128,
                     ),
                     if (widget.software == ServerSoftware.lemmy) ...[
-                      const SizedBox(height: 12),
                       TextEditor(
                         _totpTokenTextController,
                         label: l(context).totpToken,

--- a/lib/src/widgets/password_editor.dart
+++ b/lib/src/widgets/password_editor.dart
@@ -2,10 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:interstellar/src/utils/utils.dart';
 
 class PasswordEditor extends StatefulWidget {
-  const PasswordEditor(this.controller, {this.onChanged, super.key});
+  const PasswordEditor(
+    this.controller, {
+    this.onChanged,
+    this.maxLength,
+    super.key,
+  });
 
   final TextEditingController controller;
   final void Function(String)? onChanged;
+  final int? maxLength;
 
   @override
   State<PasswordEditor> createState() => _PasswordEditorState();
@@ -34,6 +40,7 @@ class _PasswordEditorState extends State<PasswordEditor> {
       onChanged: widget.onChanged,
       autofillHints: const [AutofillHints.password],
       obscureText: obscureText,
+      maxLength: widget.maxLength,
     );
   }
 }


### PR DESCRIPTION
Truncates password length to 60 for lemmy and 128 for piefed. Also adds length limits to the password textfield.
Fixes #394 