### PR TITLE
Enable using domains in feeds on mbin.

### DIFF
--- a/lib/src/api/domains.dart
+++ b/lib/src/api/domains.dart
@@ -38,6 +38,10 @@ class MbinAPIDomains {
     return DomainModel.fromMbin(response.bodyJson);
   }
 
+  Future<DomainModel> getByName(String domain) async {
+    return (await list(search: domain)).items.first;
+  }
+
   Future<DomainModel> putSubscribe(int domainId, bool state) async {
     final path = '/domain/$domainId/${state ? 'subscribe' : 'unsubscribe'}';
 

--- a/lib/src/controller/controller.dart
+++ b/lib/src/controller/controller.dart
@@ -830,7 +830,9 @@ class AppController with ChangeNotifier {
             .insertOnConflictUpdate(
               FeedInputsCompanion.insert(
                 feed: name,
-                name: normalizeName(input.name, instanceHost),
+                name: input.sourceType == FeedSource.domain
+                    ? input.name
+                    : normalizeName(input.name, instanceHost),
                 source: input.sourceType,
               ),
             );
@@ -1003,7 +1005,9 @@ class AppController with ChangeNotifier {
   }
 
   Future<int?> fetchCachedFeedInput(String name, FeedSource source) async {
-    final normalisedName = normalizeName(name, instanceHost);
+    final normalisedName = source == FeedSource.domain
+        ? name
+        : normalizeName(name, instanceHost);
     final cachedValue =
         (await (database.select(database.feedSourceCache)..where(
                   (t) =>
@@ -1028,6 +1032,7 @@ class AppController with ChangeNotifier {
                   instanceHost // tmp until proper getByName method can be made
               ? throw Exception('Wrong instance')
               : int.parse(name.split(':').first),
+        FeedSource.domain => (await api.domains.getByName(normalisedName)).id,
         _ => null,
       };
 

--- a/lib/src/screens/explore/explore_screen.dart
+++ b/lib/src/screens/explore/explore_screen.dart
@@ -286,8 +286,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
                               padding: chipPadding,
                             ),
                             const SizedBox(width: 4),
-                            if (ac.serverSoftware == ServerSoftware.mbin &&
-                                _selected == null) ...[
+                            if (ac.serverSoftware == ServerSoftware.mbin) ...[
                               ChoiceChip(
                                 label: Text(l(context).domains),
                                 selected: type == ExploreType.domains,

--- a/lib/src/screens/settings/feed_settings_screen.dart
+++ b/lib/src/screens/settings/feed_settings_screen.dart
@@ -529,11 +529,17 @@ class _EditFeedScreenState extends State<EditFeedScreen> {
                     )
                     .toSet(),
                 onTap: (selected, item) {
-                  var name = switch (item) {
-                    final DetailedCommunityModel i => i.name,
-                    final DetailedUserModel i => i.name,
+                  final name = switch (item) {
+                    final DetailedCommunityModel i => normalizeName(
+                      i.name,
+                      ac.instanceHost,
+                    ),
+                    final DetailedUserModel i => normalizeName(
+                      i.name,
+                      ac.instanceHost,
+                    ),
                     final DomainModel i => i.name,
-                    final FeedModel i => i.name,
+                    final FeedModel i => normalizeName(i.name, ac.instanceHost),
                     _ => null,
                   };
                   final source = switch (item) {
@@ -549,8 +555,6 @@ class _EditFeedScreenState extends State<EditFeedScreen> {
                   };
 
                   if (name == null || source == null) return;
-
-                  name = normalizeName(name, ac.instanceHost);
 
                   if (selected) {
                     addInput(


### PR DESCRIPTION
Uses `/api/domains?=search` to get a domain by its name instead of by id.